### PR TITLE
composerのWarning対応

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
 	"require-dev": {
-		"mikey179/vfsStream": "1.1.*",
+		"mikey179/vfsstream": "1.1.*",
 		"phpunit/phpunit": "^9.5",
 		"phpunit/php-code-coverage": "^9.2",
 		"kornrunner/dbunit": "^6.0"


### PR DESCRIPTION
### 概要
`composer install`した場合に下記のWarningが出ていたため、ライブラリを小文字に修正。

```zsh
/var/www/html # composer install
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files

```